### PR TITLE
Improve jsonify.py's output

### DIFF
--- a/jsonify.py
+++ b/jsonify.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Install dependencies:
+# pip install progressbar json_repair
+
 __author__ = "Matthew Khouzam"
 __copyright__ = "Copyright 2024, Ericsson"
 __credits__ = ["Matthew Khouzam"]
@@ -8,6 +11,7 @@ __license__ = "MIT"
 import re
 import argparse
 import progressbar
+from json_repair import repair_json
 
 widgets = [' [',
          progressbar.Timer(format= 'elapsed time: %s'),
@@ -51,16 +55,13 @@ with open(args.input, 'r') as input:
                         elif char == '}':
                             bracket_count -=1
                         if bracket_count == 0:
-                            event_line = line[index_start:index]
-                            events.append(event_line.replace('‥', ':'))
+                            # repair_json() is useful to clean-up slightly illegal
+                            # JSON.  e.g. unescaped chars in JSON string
+                            event_line = repair_json(line[index_start:index].replace('‥', ':'))
+                            events.append(event_line)
                             break
                     line = line[index:]
                     event = re.search(event_start, line)        
-                    
         output.write(',\n'.join(events))
         output.write(']\n')
 print( f'\nWrote to {args.output}')
-
-
-
-


### PR DESCRIPTION
Run json_repair#repair_json() \[1\] on each line to fix minor JSON problems, like unescaped chars in JSON strings. This should make the script's output less likely to contain non-legal JSON.

The performance hit for this change, in terms of execution time, is ~13% on my machine, using a ~1GB trace:

orig: 1m56
new: 2m11

\[1\]: License: [MIT](https://github.com/mangiucugna/json_repair/blob/main/LICENSE)