### PR TITLE
Add OSGI metadata to the generated MANIFEST.MF of the jar file

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [ 8, 11, 17 ]
+        java_version: [ 17, 21 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,6 @@
         <targetPath>META-INF</targetPath>
       </resource>
     </resources>
-    
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
@@ -210,6 +209,11 @@
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+         <version>6.0.0</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
@@ -258,5 +262,28 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+         <configuration>
+           <archive>
+             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+           </archive>
+         </configuration>
+        </plugin>
+        <plugin>
+         <groupId>org.apache.felix</groupId>
+         <artifactId>maven-bundle-plugin</artifactId>
+         <executions>
+           <execution>
+             <id>bundle-manifest</id>
+             <phase>process-classes</phase>
+             <goals>
+               <goal>manifest</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
This will make integration into OSGI projects simpler.

For example, it will generate the following MANIFEST.MF build with java 21.
```
Manifest-Version: 1.0
Build-Jdk-Spec: 21
Created-By: Apache Maven Bundle Plugin 6.0.0
Bnd-LastModified: 1737658824719
Bundle-Description: This logger is based on JUL to allow fast JSON trace
 s to be written to disk. It is not lockless or nanosecond precise, but 
 is fast and simple to use and configure.
Bundle-DocURL: https://www.eclipse.org/
Bundle-License: https://opensource.org/license/MIT
Bundle-ManifestVersion: 2
Bundle-Name: trace-event-logger
Bundle-SymbolicName: org.eclipse.tracecompass.trace-event-logger
Bundle-Vendor: Eclipse Foundation
Bundle-Version: 0.1.0
Export-Package: org.eclipse.tracecompass.trace_event_logger;version="0.1
 .0"
Import-Package: java.io,java.lang,java.lang.invoke,java.lang.reflect,jav
 a.nio.charset,java.nio.file,java.text,java.util,java.util.concurrent,ja
 va.util.concurrent.atomic,java.util.function,java.util.logging
Originally-Created-By: Apache Maven Bundle Plugin 6.0.0
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-7.0.0.202310060912

```

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>