### PR TITLE
Add basic issue and pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report (except security vulnerabilities)
+about: Create a report to help us improve
+---
+
+<!-- Please provide a detailed description of the bug. -->
+<!-- Note: This template is not meant for security vulnerabilities disclosure -->
+<!-- Any such issue, created in this repo, will be deleted on sight -->
+<!-- Instead please report vulnerabilities to the Eclipse Foundation's security team -->
+<!-- For more details, please read SECURITY.md in the repository root -->
+### Bug Description:
+
+<!-- Please provide clear steps to reproduce the bug. -->
+### Steps to Reproduce:
+
+1.
+2.
+3.
+
+<!-- Please provide any additional information available. -->
+<!-- Additional information can be in the form of logs, screenshots, screencasts. -->
+
+### Additional Information
+
+- Operating System:
+- Trace Event Logger Version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature Request
+about: Propose an idea for the project
+---
+
+<!-- Please fill out the following content for a feature request. -->
+
+<!-- Please provide a clear description of the feature and any relevant information. -->
+### Feature Description:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask a question related to the content of this repository
+---
+
+<!-- Please fill out the following content for a question. -->
+
+<!-- Please provide a clear description of your question and include any relevant information. -->
+### Your question:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for your Pull Request. Please provide a description and review
+the requirements below.
+
+Contributors guide: https://github.com/eclipse-tracecompass/trace-event-logger/blob/main/CONTRIBUTING.md
+
+Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
+other means. See SECURITY.md at the root of this repository, to learn how to report
+vulnerabilities.
+-->
+
+### What it does
+
+<!-- Include relevant issues and describe how they are addressed. -->
+
+### How to test
+
+<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
+
+### Follow-ups
+
+<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
+
+### Review checklist
+
+- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


### PR DESCRIPTION
This PR adds an issue and PR template in this repo, heavily inspired from those of the org.eclipse.tracecompass repository.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>