### PR TITLE
[tests] restore SimpleFormatter.format property modified in test

### DIFF
--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/LoggerWithHandlerTest.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/LoggerWithHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.logging.StreamHandler;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,6 +57,7 @@ public class LoggerWithHandlerTest {
     private Logger fLogger;
     private StreamHandler fStreamHandler;
     private File fTempFile;
+    private String originalFormat;
 
     /**
      * Set up logger
@@ -63,6 +65,7 @@ public class LoggerWithHandlerTest {
     @Before
     public void before() {
         try {
+            originalFormat = System.getProperty("java.util.logging.SimpleFormatter.format"); //$NON-NLS-1$
             System.setProperty("java.util.logging.SimpleFormatter.format", "%5$s%n"); //$NON-NLS-1$ //$NON-NLS-2$
             LogManager.getLogManager().reset();
             fLogger = Logger.getAnonymousLogger();
@@ -75,6 +78,18 @@ public class LoggerWithHandlerTest {
 
         } catch (IOException e) {
             fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Cleanup after test execution
+     */
+    @After
+    public void after() {
+        if (originalFormat != null) {
+            System.setProperty("java.util.logging.SimpleFormatter.format", originalFormat); //$NON-NLS-1$
+        } else {
+            System.clearProperty("java.util.logging.SimpleFormatter.format"); //$NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/trace-event-logger/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Fixes #54 

<!-- Include relevant issues and describe how they are addressed. -->
In test file LoggerWithHandlerTest.java, the following property is modified:

"java.util.logging.SimpleFormatter.format"

Depending on tests order execution, the modified property can interfere with other tests that do not expect the SimpleFormatter to have a different format vs default.

This commit takes care to reset the original value of the property, so that other tests that expect it to have the default value will have it.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The issue this PR fixes can be tricky to reproduce because it depends on test execution order. See the linked issue for instructions how to obtain the correct execution order. Once that's done confirm the issue on main. Then test again using this PR and confirm the issue is gone.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
