### PR TITLE
[tests] cleanup temp files created by tests

### DIFF
--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/AsyncFileHandlerTest.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/AsyncFileHandlerTest.java
@@ -66,7 +66,9 @@ public class AsyncFileHandlerTest {
                 new File("./src/test/java/org/eclipse/tracecompass/traceeventlogger/res/logging.properties"))) { //$NON-NLS-1$
             LogManager manager = LogManager.getLogManager();
             manager.readConfiguration(fis);
-            Handler first = new AsyncFileHandler(File.createTempFile("test", ".json").getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
+            File tmp = File.createTempFile("test", ".json");  //$NON-NLS-1$//$NON-NLS-2$
+            tmp.deleteOnExit();
+            Handler first = new AsyncFileHandler(tmp.getAbsolutePath());
             first.close();
         } catch (FileNotFoundException e) {
             fail(e.getMessage());
@@ -84,7 +86,9 @@ public class AsyncFileHandlerTest {
                 new File("./src/test/java/org/eclipse/tracecompass/traceeventlogger/res/goodlogging.properties"))) { //$NON-NLS-1$
             LogManager manager = LogManager.getLogManager();
             manager.readConfiguration(fis);
-            Handler first = new AsyncFileHandler(File.createTempFile("test", ".json").getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
+            File tmp = File.createTempFile("test", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+            tmp.deleteOnExit();
+            Handler first = new AsyncFileHandler(tmp.getAbsolutePath());
             assertEquals(Level.FINER, first.getLevel());
             first.close();
         } catch (FileNotFoundException e) {
@@ -138,6 +142,7 @@ public class AsyncFileHandlerTest {
     @Test
     public void testGetterSetters() throws SecurityException, IOException {
         File test = File.createTempFile("test", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+        test.deleteOnExit();
         AsyncFileHandler toTest = new AsyncFileHandler(test.getAbsolutePath());
         toTest.setEncoding("UTF-8"); //$NON-NLS-1$
         assertEquals("UTF-8", toTest.getEncoding()); //$NON-NLS-1$

--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/LoggerWithHandlerTest.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/LoggerWithHandlerTest.java
@@ -91,6 +91,7 @@ public class LoggerWithHandlerTest {
         } else {
             System.clearProperty("java.util.logging.SimpleFormatter.format"); //$NON-NLS-1$
         }
+        fTempFile.deleteOnExit();
     }
 
     /**

--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/SnapshotTest.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/SnapshotTest.java
@@ -218,7 +218,9 @@ public class SnapshotTest {
                 new File("./src/test/java/org/eclipse/tracecompass/traceeventlogger/res/goodlogging.properties"))) { //$NON-NLS-1$
             LogManager manager = LogManager.getLogManager();
             manager.readConfiguration(fis);
-            Handler first = new AsyncFileHandler(File.createTempFile("test", ".json").getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
+            File tmp = File.createTempFile("test", ".json");  //$NON-NLS-1$//$NON-NLS-2$
+            tmp.deleteOnExit();
+            Handler first = new AsyncFileHandler(tmp.getAbsolutePath());
             first.close();
         } catch (FileNotFoundException e) {
             fail(e.getMessage());

--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/TestLoggerBenchmark.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/TestLoggerBenchmark.java
@@ -72,7 +72,9 @@ public class TestLoggerBenchmark {
     public void testBench() throws SecurityException, IOException {
         fLogger = Logger.getAnonymousLogger();
         files[0] = File.createTempFile("trace-old", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+        files[0].deleteOnExit();
         files[1] = File.createTempFile("trace-new", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+        files[1].deleteOnExit();
         oldFileHandler = new FileHandler(files[0].getAbsolutePath());
         oldFileHandler.setFormatter(new Formatter() {
             @Override
@@ -270,7 +272,9 @@ public class TestLoggerBenchmark {
     public void testLeanBench() throws SecurityException, IOException {
         fLogger = Logger.getAnonymousLogger();
         files[0] = File.createTempFile("trace-lean-old", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+        files[0].deleteOnExit();
         files[1] = File.createTempFile("trace-lean-new", ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+        files[1].deleteOnExit();
         oldFileHandler = makeFileHandler(files[0].getAbsolutePath());
         fLogger.addHandler(oldFileHandler);
         fLogger.setLevel(Level.ALL);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/trace-event-logger/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes #58

Each time the tests are run, several files are created in the system's temp directory (/tmp on Linux), each time with new names. Some of them are quite big (from the benchmark tests) and if one runs the tests many times, it will take-up some considerable space. (almost 600MB per run)

In this commit, every place in the tests where a temporary file is created, "deleteOnExit()" is called on the returned File handle. This makes it so that the JVM will delete each of these files, before terminating its execution.

Note: I noticed that some files remain in my temp folder, with extension ".lck" that are created along-sides the test's temp files, and I think used by the locking mechanism to insure ordered writing in the files. These are not directly created by the tests as far as I can see, and they have a size of zero, and so should not take much disk space.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Clean-up your temp folder and run the test suite (from the main branch). Notice the temporary files created by the tests (see code changes in the PR for an idea of what the file names will look-like). Then clean-up your temp again and re-run the tests using this PR. Confirm that the test files are no longer left in the temp folder after the tests have finished executing. 

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A 

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
