### PR TITLE
[benchmark test] use average when asserting against perf threshold

### DIFF
--- a/src/test/java/org/eclipse/tracecompass/traceeventlogger/TestLoggerBenchmark.java
+++ b/src/test/java/org/eclipse/tracecompass/traceeventlogger/TestLoggerBenchmark.java
@@ -94,6 +94,10 @@ public class TestLoggerBenchmark {
         List<Long> syncNew = new ArrayList<>();
         List<Long> syncOld = new ArrayList<>();
         List<Long> run = new ArrayList<>();
+        long totalRuns = 0;
+        long totalAsyncNew = 0;
+        long totalSyncOld = 0;
+
         for (long runs = warmUp; runs < maxRuns; runs *= growth) {
             for (long i = 0; i < warmUp; i++) {
                 try (LogUtils.ScopeLog log = new LogUtils.ScopeLog(logger, Level.FINE, "foo")) { //$NON-NLS-1$
@@ -220,6 +224,10 @@ public class TestLoggerBenchmark {
         for (int i = 0; i < run.size(); i++) {
             float factor = (float)syncOld.get(i) / (float)asyncNew.get(i);
             asyncNewVsSyncOld.add(factor);
+            totalRuns += run.get(i);
+            totalAsyncNew += asyncNew.get(i);
+            totalSyncOld += syncOld.get(i);
+
             System.out.println(String.format("%d,%d,%d,%d,%d,%.2f", run.get(i), syncOld.get(i), syncNew.get(i), //$NON-NLS-1$
                     asyncOld.get(i), asyncNew.get(i), factor));
         }
@@ -230,13 +238,14 @@ public class TestLoggerBenchmark {
             System.out.println(String.format("%7d %13.2f %13.2f %13.2f %13.2f %27.2fx", run.get(i), syncOld.get(i)*0.000001, syncNew.get(i)*0.000001, //$NON-NLS-1$
                     asyncOld.get(i)*0.000001, asyncNew.get(i)*0.000001, factor));
         }
+        float avgFactor = (float)totalSyncOld / (float)totalAsyncNew;
+        System.out.println("\n\"Regular\" Benchmark Results - Total/Average"); //$NON-NLS-1$
+        System.out.println("Runs(#)   SyncOld(ms)  AsyncNew(ms)  AsyncNewVsSyncOld(rel perf)"); //$NON-NLS-1$
+        System.out.println(String.format("%7d %13.2f %13.2f %27.2fx", totalRuns, totalSyncOld*0.000001, totalAsyncNew*0.000001, avgFactor));//$NON-NLS-1$
 
-        for (int i = 0; i < run.size(); i++) {
-            float factor = asyncNewVsSyncOld.get(i);
-            assertTrue("Runs: " + run.get(i) + " - AsyncNew expected to be much faster vs SyncOld! " +  //$NON-NLS-1$//$NON-NLS-2$
-                    "Expected factor: > " + newAsyncPerformenceThreshold + "x, Actual: " + factor, //$NON-NLS-1$ //$NON-NLS-2$
-                    (factor > newAsyncPerformenceThreshold));
-        }
+        assertTrue("(Regular) On average AsyncNew is expected to be much faster vs SyncOld! " + //$NON-NLS-1$
+                "Expected factor: > " + newAsyncPerformenceThreshold + "x, Actual: " + avgFactor, //$NON-NLS-1$ //$NON-NLS-2$
+                (avgFactor > newAsyncPerformenceThreshold));
     }
 
     private static long linecount(Path path) throws IOException {
@@ -305,6 +314,9 @@ public class TestLoggerBenchmark {
         List<Long> syncNew = new ArrayList<>();
         List<Long> syncOld = new ArrayList<>();
         List<Long> run = new ArrayList<>();
+        long totalRuns = 0;
+        long totalAsyncNew = 0;
+        long totalSyncOld = 0;
         for (long runs = warmUp; runs < maxRuns; runs *= growth) {
             for (long i = 0; i < warmUp; i++) {
                 try (LogUtils.ScopeLog log = new LogUtils.ScopeLog(logger, Level.FINE, "foo")) { //$NON-NLS-1$
@@ -416,6 +428,9 @@ public class TestLoggerBenchmark {
         for (int i = 0; i < run.size(); i++) {
             float factor = (float)syncOld.get(i) / (float)asyncNew.get(i);
             asyncNewVsSyncOld.add(factor);
+            totalRuns += run.get(i);
+            totalAsyncNew += asyncNew.get(i);
+            totalSyncOld += syncOld.get(i);
             System.out.println(String.format("%d,%d,%d,%d,%d,%.2f", run.get(i), syncOld.get(i), syncNew.get(i), //$NON-NLS-1$
                     asyncOld.get(i), asyncNew.get(i), factor));
         }
@@ -427,13 +442,18 @@ public class TestLoggerBenchmark {
             System.out.println(String.format("%7d %13.2f %13.2f %13.2f %13.2f %27.2fx", run.get(i), syncOld.get(i)*0.000001, syncNew.get(i)*0.000001, //$NON-NLS-1$
                     asyncOld.get(i)*0.000001, asyncNew.get(i)*0.000001, factor));
         }
+
+        float avgFactor = (float)totalSyncOld / (float)totalAsyncNew;
+        System.out.println("\n\"Lean\" Benchmark Results - Total/Average"); //$NON-NLS-1$
+        System.out.println("Runs(#)   SyncOld(ms)  AsyncNew(ms)  AsyncNewVsSyncOld(rel perf)"); //$NON-NLS-1$
+        System.out.println(String.format("%7d %13.2f %13.2f %27.2fx", totalRuns, totalSyncOld*0.000001, totalAsyncNew*0.000001, avgFactor));//$NON-NLS-1$
+
+        assertTrue("(Lean) On average AsyncNew is expected to be much faster vs SyncOld! " + //$NON-NLS-1$
+                "Expected factor: > " + newAsyncPerformenceThreshold + "x, Actual: " + avgFactor, //$NON-NLS-1$ //$NON-NLS-2$
+                (avgFactor > newAsyncPerformenceThreshold));
+
+
         System.out.println("-----\n"); //$NON-NLS-1$
-        for (int i = 0; i < run.size(); i++) {
-            float factor = asyncNewVsSyncOld.get(i);
-            assertTrue("Runs: " + run.get(i) + " - AsyncNewLean expected to be much faster vs SyncOldLean! " + //$NON-NLS-1$ //$NON-NLS-2$
-                    "Expected factor: > " + newAsyncPerformenceThreshold + "x, Actual: " + factor, //$NON-NLS-1$ //$NON-NLS-2$
-                    (factor > newAsyncPerformenceThreshold));
-        }
     }
 
     private static Handler makeAsyncFileHandler(String path) throws IOException {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/trace-event-logger/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The recently added assertions in the benchmark test, that confirm that the new async handler is much more performant vs the old sync handler, were failing the test once in a while.

Originally the assertions were against each test run - those runs with fewer iterations were very sensitive to interference by e.g. GC.

e.g. imagine that a 10-20 ms GC occurs while doing one of the runs below, while performing logging using `"AsyncNew"` - it could easily make `"AsyncNew"` look much less performant vs `"SyncOld"`, once in a while making the `AsyncNewVsSyncOld` ratio look too low and failing the test:

```
Runs(#)   SyncOld(ms)   AsyncNew(ms)  AsyncNewVsSyncOld(rel perf)
   2000         75.48          8.56                        8.81x
   4600        243.99          4.24                       57.59x
  10580        239.99          9.82                       24.43x
  24333        404.66         46.39                        8.72x
```

Here's a case where it happened locally during the "10580" run for AsyncNew, just about doubling its apparent duration:
![image](https://github.com/user-attachments/assets/ca8fdf35-e78a-47aa-b70d-01e4ff03355d)

After this commit, the performance is asserted against the average performance of `AsyncNew` vs `SyncOld`, over the totals of all runs (separately for the Regular vs Lean benchmarks). The total/average info is now printed on `stdout` in human-readable form, under the existing table:

```
"Regular" Benchmark Results (Human-readable):
Runs(#)   SyncOld(ms)   SyncNew(ms)  AsyncOld(ms)  AsyncNew(ms)  AsyncNewVsSyncOld(rel perf)
   2000         73.92        103.07         16.13          6.80                       10.87x
   4600        111.18        153.01         24.33          5.25                       21.18x
  10580        177.14        232.28         64.40         18.39                        9.63x
  24333        361.16        378.44        179.38         42.53                        8.49x
  55965        880.51        817.50        435.67         47.72                       18.45x
 128719       1869.16       1867.09        822.97        178.17                       10.49x

"Regular" - Total/Average
Runs(#)   SyncOld(ms)  AsyncNew(ms)  AsyncNewVsSyncOld(rel perf)
 226197       3473.06        298.86                       11.62x
```

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Verify that CI passes.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
