### PR TITLE
[SnapshotHandler] Small improvements

### DIFF
--- a/src/main/java/org/eclipse/tracecompass/traceeventlogger/SnapshotHandler.java
+++ b/src/main/java/org/eclipse/tracecompass/traceeventlogger/SnapshotHandler.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.FileHandler;
-import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 
@@ -143,8 +142,8 @@ public class SnapshotHandler extends FileHandler {
     @Override
     public boolean isLoggable(LogRecord logRecord) {
         // feature switch here
-        return (fIsEnabled && logRecord != null && super.isLoggable(logRecord)
-                && (logRecord.getLevel().intValue() <= Level.FINE.intValue()) && (logRecord instanceof TraceEventLogRecord)); // add
+        return (fIsEnabled && super.isLoggable(logRecord)
+                && (logRecord instanceof TraceEventLogRecord)); // add
     }
 
     private boolean addToSnapshot(LogRecord message) {
@@ -168,14 +167,26 @@ public class SnapshotHandler extends FileHandler {
         case "E": //$NON-NLS-1$
         {
             InnerEvent lastEvent = stack.remove(stack.size() - 1);
+            // top-level trace "segment" for this thread?
             if (stack.isEmpty()) {
+                // some housekeeping before flushing
+                pidMap.remove(event.getTid());
+                if (pidMap.isEmpty()) {
+                    // was the last entry for this pid/tid
+                    fStacks.remove(event.getPid());
+                }
+
                 // convert to seconds
                 double delta = (event.getTs() - lastEvent.getTs()) * 0.000001;
                 if (delta > fTimeout) {
+                    Deque<InnerEvent> toDrain = fData;
+                    // Start a new in-memory event queue, so we can continue to
+                    // process new events while draining the old queue to disk
+                    fData = new ArrayDeque<>();
                     if(fAsynchronousDrain) {
-                        drain(fData);
+                        drain(toDrain);
                     } else {
-                        drainTrace(fData).run();
+                        drainTrace(toDrain).run();
                     }
                 }
             }
@@ -189,10 +200,9 @@ public class SnapshotHandler extends FileHandler {
 
     @Override
     public synchronized void publish(LogRecord record) {
-        if (record != null) {
+        if (isLoggable(record)) {
             addToSnapshot(record);
         }
-        super.publish(record);
     }
 
     private void drain(Deque<InnerEvent> data) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/trace-event-logger/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
I noticed a few things by inspecting the code of SnapshotHandler, that I am attempting to address in this commit:

In publish():
- a call is made to super.publish(), which calls parent class FileHandler's publish(). This seems unnecessary - if the file handler configuration is present, it could result in potentially the double-publishing of log records - in the snapshot log and in the file log, or more likely do nothing. In cases where this might be desirable, I think it can be accomplished by configuring handler hierarchy such that a FileHandler is the parent of SnapshotHandler.
- instead, call the overridden isLoggable() to check whether the log records should be logged, and if so, "publish" to the in-memory queue.

In the local isLoggable():
- remove the redundant null check, which is performed already in super.isLoggable()
- remove the seemingly strange log level check that filters-out anything higher than "FINE".

In addToSnapshot():
- update the in-memory "stack-tracking" structure: when the last entry for a given pid is removed, remove the corresponding list. Similarly, if that list was the last entry for the pid-level parent structure, remove that one as well. The lists will be recreated if needed later (using the existing computeIfAbsent()). This change might result in these lists being allocated/freed multiple times, but should prevent the case where a program, which creates many threads, ends-up with very many of these empty lists staying allocated indefinitely, each consuming a little heap memory.
- Make the draining of the in-memory queue to file atomic by having "publish()" use a new, empty queue, while the old queue is drained and then discarded. Before doing this, I think new log records might get added to the draining queue, if some logging occurred during draining.


### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Verify that CI passes. Ideally, I would like if there were some higher-level tests for this handler, to complement the current unit tests.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
